### PR TITLE
Fix release detection and Owlbear reconnect race

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -187,7 +187,7 @@ jobs:
           fi
           echo "already_published=true" >> "$GITHUB_OUTPUT"
         else
-          if ! grep -q 'HTTP 404' "${RUNNER_TEMP}/existing-release-error.txt"; then
+          if ! grep -qi 'release not found' "${RUNNER_TEMP}/existing-release-error.txt"; then
             cat "${RUNNER_TEMP}/existing-release-error.txt" >&2
             exit 1
           fi

--- a/src/data/owlbear/OwlbearIntegrationServer.ts
+++ b/src/data/owlbear/OwlbearIntegrationServer.ts
@@ -388,6 +388,7 @@ export class OwlbearIntegrationServer {
 	private handleConnection(client: WebSocket): void {
 		const connection: ClientConnection = { authenticated: false, handshakeTimeout: null };
 		connection.handshakeTimeout = setTimeout(() => {
+			connection.handshakeTimeout = null;
 			if (!connection.authenticated) client.terminate();
 		}, HANDSHAKE_TIMEOUT_MS);
 		client.on("message", (data, isBinary) => this.enqueueClientMessage(client, connection, data, isBinary));
@@ -429,6 +430,7 @@ export class OwlbearIntegrationServer {
 	}
 
 	private authenticateClient(client: WebSocket, connection: ClientConnection, hello: IntegrationMessage): void {
+		if (connection.authenticated || connection.handshakeTimeout === null || client.readyState !== WebSocket.OPEN) return;
 		if (hello.protocolVersion !== PROTOCOL_VERSION || typeof hello.type !== "string") {
 			this.closePendingClient(client, connection, PROTOCOL_ERROR_CLOSE_CODE, "Несовместимая версия протокола.");
 			return;

--- a/test/data/owlbear/OwlbearIntegrationServer.test.ts
+++ b/test/data/owlbear/OwlbearIntegrationServer.test.ts
@@ -342,6 +342,31 @@ describe("Owlbear integration server transport", () => {
 		expect(await pong).toMatchObject({ type: "pong" });
 	});
 
+	it("does not promote a candidate that closes before its queued hello is processed", async () => {
+		const { server } = await createRunningServer();
+		const publicUrl = `ws://127.0.0.1:${server.getPublicAssetPort()}${server.getPublicAssetPath()}/ws`;
+		const client = await openWebSocket(publicUrl, "https://vladbytsyuk.github.io");
+		const ready = waitForMessage(client, "server.ready");
+		client.send(JSON.stringify({ protocolVersion: 2, messageId: "hello-valid", type: "client.hello", token: "token" }));
+		await ready;
+		const activeClient = (server as unknown as { client: WebSocket | null }).client;
+
+		let releaseQueue!: () => void;
+		const blockedQueue = new Promise<void>((resolve) => { releaseQueue = resolve; });
+		(server as unknown as { messageQueue: Promise<void> }).messageQueue = blockedQueue;
+		const candidate = await openWebSocket(publicUrl, "https://vladbytsyuk.github.io");
+		const candidateClosed = new Promise<void>((resolve) => candidate.once("close", () => resolve()));
+		candidate.send(JSON.stringify({ protocolVersion: 2, messageId: "hello-stale", type: "client.hello", token: "token" }));
+		candidate.terminate();
+		await candidateClosed;
+
+		releaseQueue();
+		await (server as unknown as { messageQueue: Promise<void> }).messageQueue;
+
+		expect((server as unknown as { client: WebSocket | null }).client).toBe(activeClient);
+		expect(server.getStatus().connected).toBe(true);
+	});
+
 	it("rejects query parameters on the public WebSocket path", async () => {
 		const { server } = await createRunningServer();
 		const url = `ws://127.0.0.1:${server.getPublicAssetPort()}${server.getPublicAssetPath()}/ws?token=must-not-be-in-url`;


### PR DESCRIPTION
## Summary
- recognize `gh release view`'s `release not found` response so first-time releases can proceed
- prevent closed or timed-out Owlbear WebSocket candidates from replacing the active client
- add a regression test for a stale queued client handshake

## Verification
- `npm run build`
- `npm run test -- --run --reporter=dot` (107 files, 1277 tests)