### PR TITLE
Integrate Owlbear Rodeo with rounded portrait assets

### DIFF
--- a/src/data/database/DmScreenGroupSqlTableDao.ts
+++ b/src/data/database/DmScreenGroupSqlTableDao.ts
@@ -104,7 +104,9 @@ export class DmScreenGroupSqlTableDao extends Dao<DmScreenItem, any> {
                     group_name = ?,
                     group_short_name = ?,
                     group_item = ?,
-                    description = ?
+                    icon = ?,
+                    description = ?,
+                    parent_url = ?
                 WHERE url = ? COLLATE NOCASE;
             `, [
                 item.name.rus,
@@ -115,7 +117,9 @@ export class DmScreenGroupSqlTableDao extends Dao<DmScreenItem, any> {
                 item.source.group.name || null,
                 item.source.group.shortName || null,
                 item.group || null,
+                item.icon || null,
                 item.description || null,
+                item.parentUrl || null,
                 item.url
             ]);
         } catch (error) {

--- a/src/data/owlbear/OwlbearImageAssetStore.ts
+++ b/src/data/owlbear/OwlbearImageAssetStore.ts
@@ -3,6 +3,7 @@ import { mkdir, readdir, readFile, rename, stat, unlink, utimes, writeFile } fro
 import { join } from "path";
 
 const DEFAULT_MAX_BYTES = 250 * 1024 * 1024;
+const ROUND_TOKEN_SVG_MARKER = "dnd-dm-tools-round-token-v1";
 
 export type ImageAsset = {
 	assetId: string;
@@ -101,6 +102,23 @@ export function createFallbackSvg(name: string, colorHex: string | undefined, si
 	const escapedInitials = initials.replace(/[&<>"']/g, (value) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&apos;" }[value]!));
 	const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512"><circle cx="256" cy="256" r="248" fill="${color}"/><text x="256" y="286" text-anchor="middle" font-family="sans-serif" font-size="150" font-weight="700" fill="#ffffff">${escapedInitials}</text></svg>`;
 	return { assetId: "", mime: "image/svg+xml", bytes: Buffer.from(svg), };
+}
+
+export function createRoundTokenSvg(mime: string, bytes: Buffer, width: number, height: number): Buffer {
+	const diameter = roundTokenDiameter(width, height);
+	const source = `data:${mime};base64,${bytes.toString("base64")}`;
+	const radius = diameter / 2;
+	const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${diameter}" height="${diameter}" viewBox="0 0 ${diameter} ${diameter}"><metadata>${ROUND_TOKEN_SVG_MARKER}</metadata><defs><clipPath id="round-token"><circle cx="${radius}" cy="${radius}" r="${radius}"/></clipPath></defs><image href="${source}" width="${diameter}" height="${diameter}" preserveAspectRatio="xMidYMid slice" clip-path="url(#round-token)"/></svg>`;
+	return Buffer.from(svg);
+}
+
+export function isRoundTokenSvg(bytes: Buffer): boolean {
+	return bytes.includes(ROUND_TOKEN_SVG_MARKER);
+}
+
+export function roundTokenDiameter(width: number | undefined, height: number | undefined): number {
+	const smallestSide = Math.min(width ?? 512, height ?? 512);
+	return Number.isFinite(smallestSide) && smallestSide > 0 ? Math.max(1, Math.floor(smallestSide)) : 512;
 }
 
 export function createTokenVisualSvg(mime: string, bytes: Buffer, state: TokenVisualState, width: number, height: number): Buffer {

--- a/src/data/owlbear/OwlbearIntegrationServer.ts
+++ b/src/data/owlbear/OwlbearIntegrationServer.ts
@@ -217,6 +217,13 @@ export class OwlbearIntegrationServer {
 			}
 			if (!imageBytes) throw new Error(`Не удалось подготовить изображение токена «${participant.name}».`);
 			if (isRoundTokenSvg(imageBytes)) {
+				if (freshImage || !assetId) {
+					assetId = await this.imageStore.put(
+						"image/svg+xml",
+						imageBytes,
+						protectedIds.concat(materializedAssetIds),
+					);
+				}
 				mime = "image/svg+xml";
 				const diameter = roundTokenDiameter(width, height);
 				width = diameter;

--- a/src/data/owlbear/OwlbearIntegrationServer.ts
+++ b/src/data/owlbear/OwlbearIntegrationServer.ts
@@ -4,7 +4,7 @@ import { randomBytes } from "crypto";
 import { readFile } from "fs/promises";
 import { join } from "path";
 import { WebSocket, WebSocketServer, type RawData } from "ws";
-import { OwlbearImageAssetStore, createFallbackSvg, createTokenVisualSvg, type TokenVisualState } from "./OwlbearImageAssetStore";
+import { OwlbearImageAssetStore, createFallbackSvg, createRoundTokenSvg, createTokenVisualSvg, isRoundTokenSvg, roundTokenDiameter, type TokenVisualState } from "./OwlbearImageAssetStore";
 import type { OwlbearEncounterSnapshot, OwlbearSyncDiagnostics, OwlbearTokenLink } from "src/domain/models/owlbear/OwlbearSync";
 import type { OwlbearPreviewSnapshot } from "src/domain/models/owlbear/OwlbearPreview";
 import { isAllowedOwlbearExtensionOrigin } from "./OwlbearExtensionHosting";
@@ -188,30 +188,49 @@ export class OwlbearIntegrationServer {
 			let width = participant.imageWidth;
 			let height = participant.imageHeight;
 			let usedFallback = participant.imageFallback === true;
+			let imageBytes: Buffer | null = null;
 			if (freshImage) {
-				assetId = await this.imageStore.put(freshImage.mime, freshImage.bytes, protectedIds.concat(materializedAssetIds));
 				mime = freshImage.mime;
+				imageBytes = freshImage.bytes;
 				usedFallback = false;
+			} else if (assetId) {
+				imageBytes = await this.imageStore.get(assetId);
 			}
-			if (!assetId && previous?.imageSource && previous.imageSource === participant.imageSource && previous.imageAssetId) {
+			if (!imageBytes && previous?.imageSource && previous.imageSource === participant.imageSource && previous.imageAssetId) {
 				const previousBytes = await this.imageStore.get(previous.imageAssetId);
 				if (previousBytes) {
 					assetId = previous.imageAssetId;
+					imageBytes = previousBytes;
 					mime = mime ?? previous.imageMime;
 					width = width ?? previous.imageWidth;
 					height = height ?? previous.imageHeight;
 					usedFallback = previous.imageFallback === true;
 				}
 			}
-			if (!assetId || !(await this.imageStore.has(assetId))) {
-				if (!freshImage) {
-					const fallback = createFallbackSvg(participant.name, participant.colorHex, participant.side);
-					assetId = await this.imageStore.put(fallback.mime, fallback.bytes, protectedIds.concat(materializedAssetIds));
-					mime = fallback.mime;
-					width = 512;
-					height = 512;
-					usedFallback = true;
-				}
+			if (!imageBytes) {
+				const fallback = createFallbackSvg(participant.name, participant.colorHex, participant.side);
+				mime = fallback.mime;
+				imageBytes = fallback.bytes;
+				width = 512;
+				height = 512;
+				usedFallback = true;
+			}
+			if (!imageBytes) throw new Error(`Не удалось подготовить изображение токена «${participant.name}».`);
+			if (isRoundTokenSvg(imageBytes)) {
+				mime = "image/svg+xml";
+				const diameter = roundTokenDiameter(width, height);
+				width = diameter;
+				height = diameter;
+			} else {
+				const diameter = roundTokenDiameter(width, height);
+				assetId = await this.imageStore.put(
+					"image/svg+xml",
+					createRoundTokenSvg(mime ?? "image/png", imageBytes, diameter, diameter),
+					protectedIds.concat(materializedAssetIds),
+				);
+				mime = "image/svg+xml";
+				width = diameter;
+				height = diameter;
 			}
 			if (!assetId) throw new Error(`Не удалось подготовить изображение токена «${participant.name}».`);
 			const materializedParticipant = {

--- a/src/data/repositories/RacesRepository.ts
+++ b/src/data/repositories/RacesRepository.ts
@@ -14,6 +14,7 @@ import { sortSources } from "src/domain/utils/SourceSorter";
 import type { Races } from "src/domain/repositories/Races";
 import type { Group } from "src/domain/repositories/Repository";
 import type { ItemSaveContext, ItemSaveResult } from "src/domain/models/common/EntityOrigin";
+import type { EntityOriginDao } from "src/data/database/EntityOriginDao";
 import {
 	createSimpleRepositoryDependencies,
 	SimpleRepository,
@@ -86,6 +87,7 @@ export class RacesRepository
 	readonly #raceStore: RaceStore;
 	readonly #service: FullItemReadService<TtgJsonObject, TtgApiRequestOptions>;
 	readonly #mapper: FullItemMapper<TtgJsonObject, FullRace>;
+	readonly #origins: EntityOriginDao | undefined;
 
 	constructor(
 		dependencies: RaceRepositoryDatabase | RacesRepositoryDependencies,
@@ -99,6 +101,7 @@ export class RacesRepository
 		this.#raceStore = assembled.raceStore;
 		this.#service = assembled.service;
 		this.#mapper = assembled.mapper;
+		this.#origins = assembled.simpleDependencies.origins;
 	}
 
 	async collectFiltersFromAllItems(allSmallItems: SmallRace[]): Promise<RaceFilters | null> {
@@ -187,12 +190,17 @@ export class RacesRepository
 			return { ok: false, code: "manual-url-immutable", message: "URL ручной сущности нельзя изменить после создания." };
 		}
 		try {
-		const existing = await this.#raceStore.readSmallRaceByUrl(fullItem.url);
-		const updatesSameManualItem = originalOrigin === "manual" && originalUrl === fullItem.url;
-		if (existing && !updatesSameManualItem) {
+			const existing = await this.#raceStore.readSmallRaceByUrl(fullItem.url);
+			const updatesSameManualItem = originalOrigin === "manual" && originalUrl === fullItem.url;
+			if (existing && !updatesSameManualItem) {
 				return { ok: false, code: "url-occupied", message: "Этот URL уже занят в данном справочнике." };
 			}
+			const remoteCollision = await this.findRemoteCollision(fullItem);
+			if (remoteCollision) {
+				return { ok: false, code: "url-occupied", message: `URL ${remoteCollision} уже занят встроенной расой.` };
+			}
 			await this.#raceStore.saveManualRaceTree(fullItem, context.parentUrl ?? null);
+			await this.reloadCaches();
 			return { ok: true };
 		} catch {
 			return { ok: false, code: "save-failed", message: "Не удалось сохранить сущность." };
@@ -213,5 +221,16 @@ export class RacesRepository
 
 	async getSubraces(parentUrl: string): Promise<SmallRace[]> {
 		return await this.#raceStore.readSubraces(parentUrl);
+	}
+
+	private async findRemoteCollision(race: FullRace): Promise<string | null> {
+		if (!this.#origins) return null;
+		for (const subrace of race.subraces ?? []) {
+			const existing = await this.#raceStore.readSmallRaceByUrl(subrace.url);
+			if (existing && await this.#origins.get("races", subrace.url) === "remote") return subrace.url;
+			const nestedCollision = await this.findRemoteCollision(subrace);
+			if (nestedCollision) return nestedCollision;
+		}
+		return null;
 	}
 }

--- a/src/data/repositories/SimpleRepository.ts
+++ b/src/data/repositories/SimpleRepository.ts
@@ -246,7 +246,7 @@ export abstract class SimpleRepository<
 		return true;
 	}
 
-	private async reloadCaches(): Promise<void> {
+	protected async reloadCaches(): Promise<void> {
 		this.#smallItems = undefined;
 		this.#filters = undefined;
 		if (this.shouldPreloadSmallItems()) {

--- a/test/data/database/DmScreenGroupSqlTableDao.test.ts
+++ b/test/data/database/DmScreenGroupSqlTableDao.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+import { DmScreenGroupSqlTableDao } from "src/data/database/DmScreenGroupSqlTableDao";
+import type { DmScreenItem } from "src/domain/models/dm_screen/DmScreenItem";
+
+const item: DmScreenItem = {
+	name: { rus: "Очарованный", eng: "Charmed" },
+	url: "/screens/charmed",
+	order: 2,
+	source: {
+		shortName: "PHB",
+		name: "Книга игрока",
+		group: { shortName: "Basic", name: "Основные правила" },
+	},
+	group: "Состояния",
+	icon: "charmed",
+	description: "<p>Описание</p>",
+	parentUrl: "/screens/conditions",
+};
+
+describe("DmScreenGroupSqlTableDao", () => {
+	it("updates icon and parent URL together with other imported fields", async () => {
+		const database = { exec: vi.fn() };
+		const dao = new DmScreenGroupSqlTableDao(database as any, {} as any, {} as any);
+
+		await dao.updateItem(item);
+
+		const [query, values] = database.exec.mock.calls[0];
+		expect(query).toContain("icon = ?");
+		expect(query).toContain("parent_url = ?");
+		expect(values).toContain(item.icon);
+		expect(values).toContain(item.parentUrl);
+	});
+});

--- a/test/data/owlbear/OwlbearIntegrationServer.test.ts
+++ b/test/data/owlbear/OwlbearIntegrationServer.test.ts
@@ -1,10 +1,11 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { WebSocket, type RawData } from "ws";
 import { OwlbearIntegrationServer } from "src/data/owlbear/OwlbearIntegrationServer";
-import { createTokenVisualSvg } from "src/data/owlbear/OwlbearImageAssetStore";
+import { createRoundTokenSvg, createTokenVisualSvg } from "src/data/owlbear/OwlbearImageAssetStore";
 import type { OwlbearEncounterSnapshot } from "src/domain/models/owlbear/OwlbearSync";
 import type { OwlbearPreviewSnapshot } from "src/domain/models/owlbear/OwlbearPreview";
 
@@ -56,6 +57,17 @@ async function createServer(): Promise<{ server: OwlbearIntegrationServer; cache
 }
 
 describe("Owlbear integration server snapshots", () => {
+	it("creates a center-cropped circular SVG token with transparent corners", () => {
+		const token = createRoundTokenSvg("image/png", Buffer.from("PNG"), 640, 480).toString("utf8");
+
+		expect(token).toContain('width="480" height="480"');
+		expect(token).toContain("dnd-dm-tools-round-token-v1");
+		expect(token).toContain('<clipPath id="round-token"><circle cx="240" cy="240" r="240"/></clipPath>');
+		expect(token).toContain('href="data:image/png;base64,UE5H"');
+		expect(token).toContain('preserveAspectRatio="xMidYMid slice"');
+		expect(token).toContain('clip-path="url(#round-token)"');
+	});
+
 	it("wraps token assets in a native-label-safe visual SVG", () => {
 		const visual = createTokenVisualSvg("image/png", Buffer.from("PNG"), "dead", 512, 256).toString("utf8");
 
@@ -86,9 +98,31 @@ describe("Owlbear integration server snapshots", () => {
 
 		expect(participant.imageAssetId).toMatch(/^[a-f0-9]{64}$/);
 		expect(participant.imageFallback).toBe(true);
+		expect(participant.imageMime).toBe("image/svg+xml");
+		expect(participant.imageWidth).toBe(512);
+		expect(participant.imageHeight).toBe(512);
 		expect(participant.imageDataUrl).toBeUndefined();
 		expect(participant.imageUrl).toBeUndefined();
-		expect((await readFile(join(cacheDirectory, participant.imageAssetId!))).toString("utf8")).toContain("ЛР");
+		const cached = (await readFile(join(cacheDirectory, participant.imageAssetId!))).toString("utf8");
+		const embeddedFallback = /base64,([^\"]+)/.exec(cached);
+		expect(Buffer.from(embeddedFallback?.[1] ?? "", "base64").toString("utf8")).toContain("ЛР");
+		expect(cached).toContain("dnd-dm-tools-round-token-v1");
+	});
+
+	it("materializes rectangular portraits as square circular SVG assets", async () => {
+		const { server, cacheDirectory } = await createServer();
+		const prepared = await server.materializeSnapshot(snapshot({
+			participants: [{
+				...snapshot().participants[0],
+				imageDataUrl: "data:image/png;base64,UE5H",
+				imageWidth: 640,
+				imageHeight: 480,
+			}],
+		}));
+		const participant = prepared.participants[0];
+
+		expect(participant).toMatchObject({ imageMime: "image/svg+xml", imageWidth: 480, imageHeight: 480, imageFallback: false });
+		expect((await readFile(join(cacheDirectory, participant.imageAssetId!))).toString("utf8")).toContain('preserveAspectRatio="xMidYMid slice"');
 	});
 
 	it("reuses a previous asset when only combat state changes", async () => {
@@ -97,6 +131,29 @@ describe("Owlbear integration server snapshots", () => {
 		const second = await server.materializeSnapshot(snapshot({ snapshotId: "snapshot-2", participants: [{ ...first.participants[0], hpCurrent: 4 }] }), first);
 
 		expect(second.participants[0].imageAssetId).toBe(first.participants[0].imageAssetId);
+	});
+
+	it("migrates a cached raw portrait once and reuses the circular asset", async () => {
+		const { server, cacheDirectory } = await createServer();
+		const bytes = Buffer.from("LEGACY");
+		const assetId = createHash("sha256").update("image/png").update(bytes).digest("hex");
+		await writeFile(join(cacheDirectory, assetId), bytes);
+		const legacy = snapshot({
+			participants: [{
+				...snapshot().participants[0],
+				imageAssetId: assetId,
+				imageMime: "image/png",
+				imageWidth: 120,
+				imageHeight: 80,
+			}],
+		});
+
+		const migrated = await server.materializeSnapshot(legacy);
+		const repeated = await server.materializeSnapshot({ ...legacy, snapshotId: "snapshot-2", participants: migrated.participants });
+
+		expect(migrated.participants[0]).toMatchObject({ imageMime: "image/svg+xml", imageWidth: 80, imageHeight: 80 });
+		expect(migrated.participants[0].imageAssetId).not.toBe(assetId);
+		expect(repeated.participants[0].imageAssetId).toBe(migrated.participants[0].imageAssetId);
 	});
 
 	it("replaces a cached fallback when the original image becomes available", async () => {
@@ -167,6 +224,7 @@ describe("Owlbear integration server transport", () => {
 		const publishing = server.publishPreview(preview);
 		const message = await published;
 		expect(message.preview.imageUrl).toMatch(/\/token-images\/[a-f0-9]{64}\/image%2Fpng$/);
+		expect(message.preview).toMatchObject({ imageMime: "image/png", imageWidth: 32, imageHeight: 16 });
 		client.send(JSON.stringify({ protocolVersion: 2, messageId: "preview-applied", type: "preview.applied", previewId: "preview-1" }));
 		await expect(publishing).resolves.toMatchObject({ imageAssetId: expect.any(String), imageDataUrl: undefined });
 	});

--- a/test/data/owlbear/OwlbearIntegrationServer.test.ts
+++ b/test/data/owlbear/OwlbearIntegrationServer.test.ts
@@ -125,6 +125,26 @@ describe("Owlbear integration server snapshots", () => {
 		expect((await readFile(join(cacheDirectory, participant.imageAssetId!))).toString("utf8")).toContain('preserveAspectRatio="xMidYMid slice"');
 	});
 
+	it("stores a fresh portrait that is already a rounded SVG", async () => {
+		const { server } = await createServer();
+		const rounded = createRoundTokenSvg("image/png", Buffer.from("PNG"), 100, 100).toString("base64");
+		const prepared = await server.materializeSnapshot(snapshot({
+			participants: [{
+				...snapshot().participants[0],
+				imageDataUrl: `data:image/svg+xml;base64,${rounded}`,
+				imageWidth: 100,
+				imageHeight: 100,
+			}],
+		}));
+
+		expect(prepared.participants[0]).toMatchObject({
+			imageAssetId: expect.stringMatching(/^[a-f0-9]{64}$/),
+			imageMime: "image/svg+xml",
+			imageWidth: 100,
+			imageHeight: 100,
+		});
+	});
+
 	it("reuses a previous asset when only combat state changes", async () => {
 		const { server } = await createServer();
 		const first = await server.materializeSnapshot(snapshot());

--- a/test/data/repository/RacesRepository.test.ts
+++ b/test/data/repository/RacesRepository.test.ts
@@ -450,3 +450,51 @@ describe('RacesRepository - Grouping', () => {
         expect(groups[1].sort).toBe('Редкая');
     });
 });
+
+describe("RacesRepository - Manual race imports", () => {
+	it("rejects a nested subrace URL that belongs to remote content", async () => {
+		const nested = { ...fullRace1Subrace, url: "/races/remote-subrace" };
+		const race = { ...fullRace1, url: "/races/manual-parent", subraces: [nested] };
+		const raceStore = {
+			readSmallRaceByUrl: vi.fn(async (url: string) => url === nested.url ? smallRace2 : null),
+			saveManualRaceTree: vi.fn(),
+		};
+		const origins = { get: vi.fn(async () => "remote") };
+		const repo = new RacesRepository({
+			simpleDependencies: {
+				readStore: {}, writeStore: {}, service: {}, mapper: {}, projector: {}, origins,
+			},
+			raceStore,
+			service: {},
+			mapper: {},
+		} as any);
+
+		await expect(repo.putItem(race)).resolves.toMatchObject({ ok: false, code: "url-occupied" });
+		expect(raceStore.saveManualRaceTree).not.toHaveBeenCalled();
+	});
+
+	it("reloads small-item and filter caches after importing a race", async () => {
+		const race = { ...fullRace1, url: "/races/manual-parent" };
+		const savedSmallRace = { ...smallRace1, url: race.url };
+		const readAllSmallItems = vi.fn()
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([savedSmallRace]);
+		const raceStore = {
+			readSmallRaceByUrl: vi.fn().mockResolvedValue(null),
+			saveManualRaceTree: vi.fn(),
+		};
+		const repo = new RacesRepository({
+			simpleDependencies: {
+				readStore: { readAllSmallItems }, writeStore: {}, service: {}, mapper: {}, projector: {},
+			},
+			raceStore,
+			service: {},
+			mapper: {},
+		} as any);
+
+		await repo.initialize();
+		await expect(repo.putItem(race)).resolves.toEqual({ ok: true });
+		await expect(repo.getAllSmallItems()).resolves.toEqual([savedSmallRace]);
+		expect(readAllSmallItems).toHaveBeenCalledTimes(2);
+	});
+});


### PR DESCRIPTION
## Summary

- Add Owlbear Rodeo integration server and image asset hosting.
- Track entity origins and support archiving manually managed entities.
- Update repositories, database stores, UI panels, settings, documentation, and branding assets.
- Add and update coverage for Owlbear integration, repositories, and archive behavior.

## Testing

- Added and updated unit tests for integration hosting, repository behavior, and manual entity archiving.
- Not run (not requested).